### PR TITLE
BUGFIX ShopifyProduct - hide from menus by default

### DIFF
--- a/src/Page/ShopifyProduct.php
+++ b/src/Page/ShopifyProduct.php
@@ -82,6 +82,13 @@ class ShopifyProduct extends \Page
     ];
 
     /**
+     * @var int[]
+     */
+    private static $defaults = [
+        'ShowInMenus' => 0,
+    ];
+
+    /**
      * @var string
      */
     private static $default_sort = 'Created DESC';


### PR DESCRIPTION
closes #54