### PR TITLE
REFACTOR require osiset/basic-shopify-api for Shopify API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "guzzlehttp/guzzle": "^6.3",
         "littlegiant/silverstripe-catalogmanager": "^5.2",
         "silverstripe/recipe-cms": "^4.5",
-        "symbiote/silverstripe-gridfieldextensions": "^3.0"
+        "symbiote/silverstripe-gridfieldextensions": "^3.0",
+        "osiset/basic-shopify-api": "^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -159,6 +159,7 @@ class ShopifyClient
                     productType
                     createdAt
                     updatedAt
+                    publishedOnCurrentPublication
                     images(first: 10) {
                         edges {
                             node {
@@ -168,7 +169,7 @@ class ShopifyClient
                             }
                         }
                     }
-                    variants(first: 10) {
+                    variants(first: 25) {
                         edges {
                             node {
                                 id
@@ -229,28 +230,6 @@ class ShopifyClient
     }
 }
 ");
-    }
-
-    /**
-     * Get available product listing ids
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function productListingIds(array $options = [])
-    {
-        return $this->getClient()->graph('
-{
-  products(first: 250) {
-    edges {
-      node {
-        id
-      }
-    }
-  }
-}
-        ');
-
-        //return $this->client->request('GET', "product_listings/product_ids.json", $options);
     }
 
     /**

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -16,6 +16,8 @@ use SilverStripe\View\ArrayData;
 /**
  * Class ShopifyClient
  * @package Dynamic\Shopify\Client
+ *
+ * @mixin BasicShopifyAPI
  */
 class ShopifyClient
 {
@@ -68,6 +70,71 @@ class ShopifyClient
      * @var BasicShopifyAPI
      */
     protected $client = null;
+
+    /**
+     * Get the configured Guzzle client
+     *
+     * @throws Exception
+     */
+    public function __construct()
+    {
+        $this->setClient();
+    }
+
+    /**
+     * @param string $method
+     * @param array $args
+     */
+    public function __call(string $method, array $args)
+    {
+        return call_user_func_array([$this->getClient(), $method], $args);
+    }
+
+    /**
+     * @return $this
+     * @throws Exception
+     *
+     * TODO move config fetches to separate methods, supporting ENV values as well
+     */
+    protected function setClient()
+    {
+        /*if (!$key = self::config()->get('api_key')) {
+            throw new Exception('No api key is set.', self::EXCEPTION_NO_API_KEY);
+        }//*/
+
+        if (!$password = self::config()->get('api_password')) {
+            throw new Exception('No api password is set.', self::EXCEPTION_NO_API_PASSWORD);
+        }
+
+        if (!$domain = self::config()->get('shopify_domain')) {
+            throw new Exception('No shopify domain is set.', self::EXCEPTION_NO_DOMAIN);
+        }
+
+        $options = new Options();
+        $options->setVersion('2020-01');//static::config()->get('api_version')
+        $options->setApiPassword($password);
+        $options->setType(true);
+
+        $client = new BasicShopifyAPI($options);
+        $client->setSession(new Session($domain));
+
+        $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * @return BasicShopifyAPI|null
+     * @throws Exception
+     */
+    protected function getClient()
+    {
+        if (!$this->client) {
+            $this->setClient();
+        }
+
+        return $this->client;
+    }
 
     /**
      * @param array $options
@@ -200,61 +267,5 @@ class ShopifyClient
     }
 }
         ");
-    }
-
-    /**
-     * Get the configured Guzzle client
-     *
-     * @throws Exception
-     */
-    public function __construct()
-    {
-        $this->setClient();
-    }
-
-    /**
-     * @return $this
-     * @throws Exception
-     *
-     * TODO move config fetches to separate methods, supporting ENV values as well
-     */
-    protected function setClient()
-    {
-        /*if (!$key = self::config()->get('api_key')) {
-            throw new Exception('No api key is set.', self::EXCEPTION_NO_API_KEY);
-        }//*/
-
-        if (!$password = self::config()->get('api_password')) {
-            throw new Exception('No api password is set.', self::EXCEPTION_NO_API_PASSWORD);
-        }
-
-        if (!$domain = self::config()->get('shopify_domain')) {
-            throw new Exception('No shopify domain is set.', self::EXCEPTION_NO_DOMAIN);
-        }
-
-        $options = new Options();
-        $options->setVersion('2020-01');//static::config()->get('api_version')
-        $options->setApiPassword($password);
-        $options->setType(true);
-
-        $client = new BasicShopifyAPI($options);
-        $client->setSession(new Session($domain));
-
-        $this->client = $client;
-
-        return $this;
-    }
-
-    /**
-     * @return BasicShopifyAPI|null
-     * @throws Exception
-     */
-    protected function getClient()
-    {
-        if (!$this->client) {
-            $this->setClient();
-        }
-
-        return $this->client;
     }
 }

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -143,8 +143,8 @@ class ShopifyClient
      */
     public function products(int $limit = 10, string $cursor = null)
     {
-        return $this->getClient()->graph('
-        query ($limit: Int!, $cursor: String) {
+        return $this->getClient()->graph(
+            'query ($limit: Int!, $cursor: String) {
   products(first: $limit, after: $cursor) {
     edges {
       cursor
@@ -196,7 +196,8 @@ class ShopifyClient
             [
                 'limit' => (int)$limit,
                 'cursor' => $cursor
-            ]);
+            ]
+        );
     }
 
     /**
@@ -207,8 +208,8 @@ class ShopifyClient
      */
     public function product($productId, array $options = [])
     {
-        return $this->getClient()->graph('
-query ($id: String!){
+        return $this->getClient()->graph(
+            'query ($id: String!){
     product(id: $id) {
         id
         title
@@ -233,7 +234,8 @@ query ($id: String!){
 ',
             [
                 'id' => "gid://shopify/Product/{$productId}",
-            ]);
+            ]
+        );
     }
 
     /**

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -244,8 +244,8 @@ class ShopifyClient
     }
 }
             ',
-            $options)
-        ;
+            $options
+        );
     }
 
     /**

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -143,59 +143,60 @@ class ShopifyClient
      */
     public function products(int $limit = 10, string $cursor = null)
     {
-        $after = ($cursor) ? ", after: \"{$cursor}\"" : ' ';
-        return $this->getClient()->graph("
-{
-    shop {
-        products(first: {$limit} {$after}) {
-            edges {
-                cursor
-                node {
-                    id
-                    title
-                    handle
-                    descriptionHtml
-                    vendor
-                    productType
-                    createdAt
-                    updatedAt
-                    publishedOnCurrentPublication
-                    images(first: 10) {
-                        edges {
-                            node {
-                                id
-                                altText
-                                originalSrc
-                            }
-                        }
-                    }
-                    variants(first: 25) {
-                        edges {
-                            node {
-                                id
-                                title
-                                sku
-                                price
-                                compareAtPrice
-                                position
-                                inventoryQuantity
-                                image {
-                                    id
-                                    altText
-                                    originalSrc
-                                }
-                            }
-                        }
-                    }
-                }
+        return $this->getClient()->graph('
+        query ($limit: Int!, $cursor: String) {
+  products(first: $limit, after: $cursor) {
+    edges {
+      cursor
+      node {
+        id
+        title
+        handle
+        descriptionHtml
+        vendor
+        productType
+        createdAt
+        updatedAt
+        publishedOnCurrentPublication
+        images(first: 10) {
+          edges {
+            node {
+              id
+              altText
+              originalSrc
             }
-            pageInfo {
-              hasNextPage
-            }
+          }
         }
+        variants(first: 25) {
+          edges {
+            node {
+              id
+              title
+              sku
+              price
+              compareAtPrice
+              position
+              inventoryQuantity
+              image {
+                id
+                altText
+                originalSrc
+              }
+            }
+          }
+        }
+      }
     }
+    pageInfo {
+      hasNextPage
+    }
+  }
 }
-        ");
+',
+            [
+                'limit' => (int)$limit,
+                'cursor' => $cursor
+            ]);
     }
 
     /**
@@ -206,9 +207,9 @@ class ShopifyClient
      */
     public function product($productId, array $options = [])
     {
-        return $this->getClient()->graph("
-{
-    product(id: \"gid://shopify/Product/{$productId}\") {
+        return $this->getClient()->graph('
+query ($id: String!){
+    product(id: $id) {
         id
         title
         bodyHtml
@@ -229,7 +230,10 @@ class ShopifyClient
         }
     }
 }
-");
+',
+            [
+                'id' => "gid://shopify/Product/{$productId}",
+            ]);
     }
 
     /**
@@ -240,38 +244,36 @@ class ShopifyClient
      */
     public function collections(int $limit = 25, string $cursor = null)
     {
-        $after = ($cursor) ? ", after: \"{$cursor}\"" : ' ';
-        $query = "
-{
-    shop {
-        collections(first: {$limit} {$after}) {
-            edges {
-                cursor
-                node {
+        return $this->getClient()->graph('
+query ($limit: Int!, $cursor: String){
+    collections(first: $limit, after: $cursor) {
+        edges {
+            cursor
+            node {
+                id
+                title
+                handle
+                descriptionHtml
+                productsCount
+                updatedAt
+                sortOrder
+                publishedOnCurrentPublication
+                image {
                     id
-                    title
-                    handle
-                    descriptionHtml
-                    productsCount
-                    updatedAt
-                    sortOrder
-                    publishedOnCurrentPublication
-                    image {
-                        id
-                        altText
-                        originalSrc
-                    }
+                    altText
+                    originalSrc
                 }
             }
-            pageInfo {
-              hasNextPage
-            }
+        }
+        pageInfo {
+          hasNextPage
         }
     }
 }
-        ";
-
-        return $this->getClient()->graph($query);
+        ', [
+            'limit' => (int)$limit,
+            'cursor' => $cursor,
+        ]);
     }
 
     /**
@@ -282,12 +284,11 @@ class ShopifyClient
      * @return array|Promise
      * @throws Exception
      */
-    public function collectionProducts($handle, array $options = [])
+    public function collectionProducts($handle)
     {
         return $this->getClient()->graph(
-            "
-{
-    collectionByHandle(handle: \"{$handle}\") {
+            'query ($handle: String!){
+    collectionByHandle(handle: $handle) {
         products(first: 100) {
             edges {
                 node {
@@ -297,9 +298,8 @@ class ShopifyClient
             }
         }
     }
-}
-            ",
-            $options
+}',
+            ["handle" => $handle]
         );
     }
 }

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -147,7 +147,7 @@ class ShopifyClient
             '
 {
     shop {
-        products(first: 250) {
+        products(first: 50) {
             edges {
                 node {
                     id
@@ -158,6 +158,15 @@ class ShopifyClient
                     productType
                     createdAt
                     updatedAt
+                    images(first: 10) {
+                        edges {
+                            node {
+                                id
+                                altText
+                                originalSrc
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -188,6 +197,15 @@ class ShopifyClient
         handle
         updatedAt
         tags
+        images(first: 10) {
+            edges {
+                node {
+                    id
+                    altText
+                    originalSrc
+                }
+            }
+        }
     }
 }
 ");
@@ -238,6 +256,11 @@ class ShopifyClient
                     updatedAt
                     sortOrder
                     publishedOnCurrentPublication
+                    image {
+                        id
+                        altText
+                        originalSrc
+                    }
                 }
             }
         }

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -141,14 +141,15 @@ class ShopifyClient
      * @return array|Promise
      * @throws Exception
      */
-    public function products(array $options = [])
+    public function products(int $limit = 10, string $cursor = null)
     {
-        return $this->getClient()->graph(
-            '
+        $after = ($cursor) ? ", after: \"{$cursor}\"" : ' ';
+        return $this->getClient()->graph("
 {
     shop {
-        products(first: 50) {
+        products(first: {$limit} {$after}) {
             edges {
+                cursor
                 node {
                     id
                     title
@@ -167,14 +168,33 @@ class ShopifyClient
                             }
                         }
                     }
+                    variants(first: 10) {
+                        edges {
+                            node {
+                                id
+                                title
+                                sku
+                                price
+                                compareAtPrice
+                                position
+                                inventoryQuantity
+                                image {
+                                    id
+                                    altText
+                                    originalSrc
+                                }
+                            }
+                        }
+                    }
                 }
+            }
+            pageInfo {
+              hasNextPage
             }
         }
     }
 }
-            ',
-            $options
-        );
+        ");
     }
 
     /**
@@ -239,14 +259,15 @@ class ShopifyClient
      * @return mixed|\Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function collections(array $options = [])
+    public function collections(int $limit = 25, string $cursor = null)
     {
-        return $this->getClient()->graph(
-            '
+        $after = ($cursor) ? ", after: \"{$cursor}\"" : ' ';
+        $query = "
 {
     shop {
-        collections(first: 250) {
+        collections(first: {$limit} {$after}) {
             edges {
+                cursor
                 node {
                     id
                     title
@@ -263,12 +284,15 @@ class ShopifyClient
                     }
                 }
             }
+            pageInfo {
+              hasNextPage
+            }
         }
     }
 }
-            ',
-            $options
-        );
+        ";
+
+        return $this->getClient()->graph($query);
     }
 
     /**

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -131,7 +131,19 @@ class ShopifyClient
      */
     public function productListingIds(array $options = [])
     {
-        return $this->client->request('GET', "product_listings/product_ids.json", $options);
+        return $this->getClient()->graph('
+{
+  products(first: 250) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+        ');
+
+        //return $this->client->request('GET', "product_listings/product_ids.json", $options);
     }
 
     /**
@@ -142,18 +154,52 @@ class ShopifyClient
      */
     public function collections(array $options = [])
     {
-        return $this->client->request('GET', 'custom_collections.json', $options);
+        return $this->getClient()->graph('
+{
+    shop {
+        collections(first: 250) {
+            edges {
+                node {
+                    id
+                    title
+                    handle
+                    descriptionHtml
+                    productsCount
+                    updatedAt
+                    sortOrder
+                    publishedOnCurrentPublication
+                }
+            }
+        }
+    }
+}
+');
     }
 
     /**
-     * Get the connections between Products and Collections
+     * return products of a given collection by handle
      *
-     * @return mixed|\Psr\Http\Message\ResponseInterface
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @param $handle
+     * @param array $options
+     * @return array|Promise
+     * @throws Exception
      */
-    public function collects(array $options = [])
+    public function collectionProducts($handle, array $options = [])
     {
-        return $this->client->request('GET', 'collects.json', $options);
+        return $this->getClient()->graph("
+{
+    collectionByHandle(handle: \"{$handle}\") {
+        products(first: 100) {
+            edges {
+                node {
+                    id
+                    title
+                }
+            }
+        }
+    }
+}
+        ");
     }
 
     /**

--- a/src/Client/ShopifyClient.php
+++ b/src/Client/ShopifyClient.php
@@ -143,7 +143,8 @@ class ShopifyClient
      */
     public function products(array $options = [])
     {
-        return $this->getClient()->graph('
+        return $this->getClient()->graph(
+            '
 {
     shop {
         products(first: 250) {
@@ -151,19 +152,20 @@ class ShopifyClient
                 node {
                     id
                     title
-                    bodyHtml
+                    handle
+                    descriptionHtml
                     vendor
                     productType
                     createdAt
-                    handle
                     updatedAt
-                    tags
                 }
             }
         }
     }
 }
-');
+            ',
+            $options
+        );
     }
 
     /**
@@ -221,7 +223,8 @@ class ShopifyClient
      */
     public function collections(array $options = [])
     {
-        return $this->getClient()->graph('
+        return $this->getClient()->graph(
+            '
 {
     shop {
         collections(first: 250) {
@@ -240,7 +243,9 @@ class ShopifyClient
         }
     }
 }
-');
+            ',
+            $options)
+        ;
     }
 
     /**
@@ -253,7 +258,8 @@ class ShopifyClient
      */
     public function collectionProducts($handle, array $options = [])
     {
-        return $this->getClient()->graph("
+        return $this->getClient()->graph(
+            "
 {
     collectionByHandle(handle: \"{$handle}\") {
         products(first: 100) {
@@ -266,6 +272,8 @@ class ShopifyClient
         }
     }
 }
-        ");
+            ",
+            $options
+        );
     }
 }

--- a/src/Model/ShopifyFile.php
+++ b/src/Model/ShopifyFile.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Client;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read;

--- a/src/Model/ShopifyFile.php
+++ b/src/Model/ShopifyFile.php
@@ -33,7 +33,7 @@ class ShopifyFile extends File
      */
     private static $db = [
         'ShopifyID' => 'Varchar',
-        'OriginalSrc' => 'Varchar',
+        'OriginalSrc' => 'Varchar(255)',
         'Width' => 'Int',
         'Height' => 'Int',
         'SortOrder' => 'Int',
@@ -44,11 +44,11 @@ class ShopifyFile extends File
      */
     private static $data_map = [
         'id' => 'ShopifyID',
-        'alt' => 'Title',
-        'position' => 'SortOrder',
-        'src' => 'OriginalSrc',
-        'created_at' => 'Created',
-        'updated_at' => 'LastEdited',
+        'altText' => 'Title',
+        //'position' => 'SortOrder',
+        'originalSrc' => 'OriginalSrc',
+        //'created_at' => 'Created',
+        //'updated_at' => 'LastEdited',
         'width' => 'Width',
         'height' => 'Height',
     ];
@@ -130,13 +130,12 @@ class ShopifyFile extends File
         if (!$image = self::getByShopifyID($shopifyImage->id)) {
             $image = self::create();
         }
-
         $map = self::config()->get('data_map');
         ShopifyImportTask::loop_map($map, $image, $shopifyImage);
 
         // import the image if the source has changed
         if ($image->isChanged('OriginalSrc', DataObject::CHANGE_VALUE)) {
-            $folder = isset($shopifyImage->product_id) ? $shopifyImage->product_id : 'collection';
+            $folder = isset($image->ProductID) ? $image->ProductID : 'collection';
             $image->downloadImage($image->OriginalSrc, "shopify/$folder");
         }
 

--- a/src/Model/ShopifyFile.php
+++ b/src/Model/ShopifyFile.php
@@ -163,6 +163,8 @@ class ShopifyFile extends File
     /**
      * Download the image from the shopify CDN
      *
+     * todo - create method in ShopifyClient for $request, update function for graphql
+     *
      * @param $src
      * @param $folder
      * @throws \GuzzleHttp\Exception\GuzzleException

--- a/src/Model/ShopifyVariant.php
+++ b/src/Model/ShopifyVariant.php
@@ -88,11 +88,11 @@ class ShopifyVariant extends DataObject
         'id'=> 'ShopifyID',
         'sku'=> 'SKU',
         'price'=> 'Price',
-        'compare_at_price'=> 'CompareAtPrice',
+        'compareAtPrice'=> 'CompareAtPrice',
         'position' => 'SortOrder',
-        'created_at' => 'Created',
-        'updated_at' => 'LastEdited',
-        'inventory_quantity' => 'Inventory',
+        'createdAt' => 'Created',
+        'updatedAt' => 'LastEdited',
+        'inventoryQuantity' => 'Inventory',
     ];
 
     /**
@@ -131,9 +131,18 @@ class ShopifyVariant extends DataObject
         $map = self::config()->get('data_map');
         ShopifyImportTask::loop_map($map, $variant, $shopifyVariant);
 
-        if ($file = ShopifyFile::getByShopifyID($shopifyVariant->image_id)) {
-            $variant->FileID = $file->ID;
+        if (isset($shopifyVariant->image)) {
+            $exploded = explode('/', $shopifyVariant->image->id);
+            $imageID = end($exploded);
+
+            if ($file = ShopifyFile::getByShopifyID($imageID)) {
+                $variant->FileID = $file->ID;
+            } else {
+                $file = ShopifyFile::findOrMakeFromShopifyData($shopifyVariant->image);
+                $variant->FileID = $file->ID;
+            }
         }
+
 
         if ($variant->isChanged()) {
             $variant->write();

--- a/src/Model/ShopifyVariant.php
+++ b/src/Model/ShopifyVariant.php
@@ -65,6 +65,7 @@ class ShopifyVariant extends DataObject
     private static $summary_fields = [
         'File.CMSThumbnail' => 'Image',
         'Title',
+        'Product.Title' => 'Title',
         'Price.Nice' => 'Price',
         'SKU',
         'ShopifyID'
@@ -132,8 +133,7 @@ class ShopifyVariant extends DataObject
         ShopifyImportTask::loop_map($map, $variant, $shopifyVariant);
 
         if (isset($shopifyVariant->image)) {
-            $exploded = explode('/', $shopifyVariant->image->id);
-            $imageID = end($exploded);
+            $imageID = ShopifyImportTask::parseShopifyID($shopifyVariant->image->id);
 
             if ($file = ShopifyFile::getByShopifyID($imageID)) {
                 $variant->FileID = $file->ID;

--- a/src/Page/ShopifyCollection.php
+++ b/src/Page/ShopifyCollection.php
@@ -29,8 +29,9 @@ class ShopifyCollection extends \Page
      */
     private static $db = [
         'ShopifyID' => 'Varchar',
+        'ProductsCt' => 'Int',
+        'SortOrder' => 'Varchar(20)',
         'Published' => 'Boolean',
-        'PublishedAt' => 'Datetime',
     ];
 
     /**
@@ -38,13 +39,14 @@ class ShopifyCollection extends \Page
      */
     private static $data_map = [
         'id' => 'ShopifyID',
-        'handle' => 'URLSegment',
         'title' => 'Title',
-        'body_html' => 'Content',
-        'updated_at' => 'LastEdited',
-        'created_at' => 'Created',
-        'published' => 'Published',
-        'published_at' => 'PublishedAt',
+        'handle' => 'URLSegment',
+        'descriptionHtml' => 'Content',
+        'productsCount' => 'ProductsCt',
+        'createdAt' => 'Created',
+        'updatedAt' => 'LastEdited',
+        'sortOrder' => 'SortOrder',
+        'publishedOnCurrentPublication' => 'Published',
     ];
 
     /**

--- a/src/Page/ShopifyCollection.php
+++ b/src/Page/ShopifyCollection.php
@@ -95,7 +95,8 @@ class ShopifyCollection extends \Page
     private static $summary_fields = [
         'File.CMSThumbnail' => 'Image',
         'Title',
-        'ShopifyID'
+        'ShopifyID',
+        'ProductsCt' => 'Products',
     ];
 
     /**

--- a/src/Page/ShopifyCollection.php
+++ b/src/Page/ShopifyCollection.php
@@ -31,7 +31,7 @@ class ShopifyCollection extends \Page
         'ShopifyID' => 'Varchar',
         'ProductsCt' => 'Int',
         'SortOrder' => 'Varchar(20)',
-        'Published' => 'Boolean',
+        'CollectionActive' => 'Boolean',
     ];
 
     /**
@@ -46,7 +46,7 @@ class ShopifyCollection extends \Page
         'createdAt' => 'Created',
         'updatedAt' => 'LastEdited',
         'sortOrder' => 'SortOrder',
-        'publishedOnCurrentPublication' => 'Published',
+        'publishedOnCurrentPublication' => 'CollectionActive',
     ];
 
     /**
@@ -130,7 +130,7 @@ class ShopifyCollection extends \Page
                 UploadField::create('File')
                     ->setTitle('Image')
                     ->performReadonlyTransformation(),
-                ReadonlyField::create('Published'),
+                ReadonlyField::create('CollectionActive'),
                 ReadonlyField::create('PublishedAt'),
             ]);
 

--- a/src/Page/ShopifyProduct.php
+++ b/src/Page/ShopifyProduct.php
@@ -114,7 +114,7 @@ class ShopifyProduct extends \Page
         'Content',
         'Vendor',
         'ProductType',
-        'Tags'
+        //'Tags'
     ];
 
     /**

--- a/src/Page/ShopifyProduct.php
+++ b/src/Page/ShopifyProduct.php
@@ -38,8 +38,8 @@ class ShopifyProduct extends \Page
         'ShopifyID' => 'Varchar',
         'Vendor' => 'Varchar',
         'ProductType' => 'Varchar',
-        'Tags' => 'Varchar',
-        'Status' => 'Varchar(20)',
+        //'Tags' => 'Varchar',
+        //'Status' => 'Varchar(20)',
     ];
 
     /**
@@ -125,14 +125,13 @@ class ShopifyProduct extends \Page
     private static $data_map = [
         'id' => 'ShopifyID',
         'title' => 'Title',
-        'bodyHtml' => 'Content',
+        'handle' => 'URLSegment',
+        'descriptionHtml' => 'Content',
         'vendor' => 'Vendor',
         'productType' => 'ProductType',
         'createdAt' => 'Created',
-        'handle' => 'URLSegment',
-        'status' => 'Status',
         'updatedAt' => 'LastEdited',
-        'tags' => 'Tags',
+        //'tags' => 'Tags',
     ];
 
     /**
@@ -176,8 +175,8 @@ class ShopifyProduct extends \Page
                     ReadonlyField::create('ShopifyID'),
                     ReadonlyField::create('Vendor'),
                     ReadonlyField::create('ProductType'),
-                    ReadonlyField::create('Tags'),
-                    ReadonlyField::create('Status'),
+                    //ReadonlyField::create('Tags'),
+                    //ReadonlyField::create('Status'),
                 ]
             );
 

--- a/src/Page/ShopifyProduct.php
+++ b/src/Page/ShopifyProduct.php
@@ -39,7 +39,7 @@ class ShopifyProduct extends \Page
         'Vendor' => 'Varchar',
         'ProductType' => 'Varchar',
         //'Tags' => 'Varchar',
-        //'Status' => 'Varchar(20)',
+        'ProductActive' => 'Boolean',
     ];
 
     /**
@@ -132,6 +132,7 @@ class ShopifyProduct extends \Page
         'createdAt' => 'Created',
         'updatedAt' => 'LastEdited',
         //'tags' => 'Tags',
+        'publishedOnCurrentPublication' => 'ProductActive'
     ];
 
     /**
@@ -176,7 +177,7 @@ class ShopifyProduct extends \Page
                     ReadonlyField::create('Vendor'),
                     ReadonlyField::create('ProductType'),
                     //ReadonlyField::create('Tags'),
-                    //ReadonlyField::create('Status'),
+                    ReadonlyField::create('ProductActive'),
                 ]
             );
 

--- a/src/Page/ShopifyProduct.php
+++ b/src/Page/ShopifyProduct.php
@@ -125,13 +125,13 @@ class ShopifyProduct extends \Page
     private static $data_map = [
         'id' => 'ShopifyID',
         'title' => 'Title',
-        'body_html' => 'Content',
+        'bodyHtml' => 'Content',
         'vendor' => 'Vendor',
-        'product_type' => 'ProductType',
-        'created_at' => 'Created',
+        'productType' => 'ProductType',
+        'createdAt' => 'Created',
         'handle' => 'URLSegment',
         'status' => 'Status',
-        'updated_at' => 'LastEdited',
+        'updatedAt' => 'LastEdited',
         'tags' => 'Tags',
     ];
 

--- a/src/Task/ShopifyImportTask.php
+++ b/src/Task/ShopifyImportTask.php
@@ -109,7 +109,6 @@ class ShopifyImportTask extends BuildTask
                     }
 
                     $lastId = $shopifyCollection->cursor;
-
                 } else {
                     self::log("[{$shopifyCollection->node->id}] Could not create collection", self::ERROR);
                 }

--- a/src/Task/ShopifyImportTask.php
+++ b/src/Task/ShopifyImportTask.php
@@ -100,22 +100,37 @@ class ShopifyImportTask extends BuildTask
                     // Set current publish status for collection
                     if ($collection->CollectionActive && !$collection->isLiveVersion()) {
                         $collection->publishSingle();
-                        self::log("[{$collection->ShopifyID}] Published collection {$collection->Title}", self::SUCCESS);
+                        self::log(
+                            "[{$collection->ShopifyID}] Published collection {$collection->Title}",
+                            self::SUCCESS
+                        );
                     } elseif (!$collection->CollectionActive && $collection->IsPublished()) {
                         $collection->doUnpublish();
-                        self::log("[{$collection->ShopifyID}] Collection not active on Shopify, unpublished", self::SUCCESS);
+                        self::log(
+                            "[{$collection->ShopifyID}] Collection not active on Shopify, unpublished",
+                            self::SUCCESS
+                        );
                     } else {
-                        self::log("[{$collection->ShopifyID}] Collection {$collection->Title} is already published", self::SUCCESS);
+                        self::log(
+                            "[{$collection->ShopifyID}] Collection {$collection->Title} is already published",
+                            self::SUCCESS
+                        );
                     }
 
                     $lastId = $shopifyCollection->cursor;
                 } else {
-                    self::log("[{$shopifyCollection->node->id}] Could not create collection", self::ERROR);
+                    self::log(
+                        "[{$shopifyCollection->node->id}] Could not create collection",
+                        self::ERROR
+                    );
                 }
             }
 
             if ($lastId !== $sinceId) {
-                self::log("[{$sinceId}] Try to import the next page of collections since last cursor", self::SUCCESS);
+                self::log(
+                    "[{$sinceId}] Try to import the next page of collections since last cursor",
+                    self::SUCCESS
+                );
                 $this->importCollections($client, $lastId, $keepCollections);
             } else {
                 // Cleanup old collections
@@ -179,6 +194,7 @@ class ShopifyImportTask extends BuildTask
                                 $image->doUnpublish();
                                 $image->delete();
                                 self::log(
+                                    // phpcs:ignore Generic.Files.LineLength.TooLong
                                     "[{$imageId}][{$imageShopifyId}] Deleted old image {$image->Title} connected to product",
                                     self::SUCCESS
                                 );
@@ -194,7 +210,10 @@ class ShopifyImportTask extends BuildTask
                                     $variant->ProductID = $product->ID;
                                     if ($variant->isChanged()) {
                                         $variant->write();
-                                        self::log("[{$variant->ShopifyID}] Saved Variant {$variant->Title}", self::SUCCESS);
+                                        self::log(
+                                            "[{$variant->ShopifyID}] Saved Variant {$variant->Title}",
+                                            self::SUCCESS
+                                        );
                                     }
                                     $keepVariants[] = $variant->ID;
                                     $product->Variants()->add($variant);
@@ -207,6 +226,7 @@ class ShopifyImportTask extends BuildTask
                                 $variantShopifyId = $variant->ShopifyID;
                                 $variant->delete();
                                 self::log(
+                                    // phpcs:ignore Generic.Files.LineLength.TooLong
                                     "[{$variantId}][{$variantShopifyId}] Deleted old variant {$variant->Title} connected to product",
                                     self::SUCCESS
                                 );
@@ -216,20 +236,35 @@ class ShopifyImportTask extends BuildTask
                         // Write the product record if changed
                         if ($product->isChanged()) {
                             $product->write();
-                            self::log("[{$product->ShopifyID}] Saved changes in product {$product->Title}", self::SUCCESS);
+                            self::log(
+                                "[{$product->ShopifyID}] Saved changes in product {$product->Title}",
+                                self::SUCCESS
+                            );
                         } else {
-                            self::log("[{$product->ShopifyID}] Product {$product->Title} has no changes", self::SUCCESS);
+                            self::log(
+                                "[{$product->ShopifyID}] Product {$product->Title} has no changes",
+                                self::SUCCESS
+                            );
                         }
 
                         // Set current publish status for product
                         if ($product->ProductActive && !$product->isLiveVersion()) {
                             $product->publishSingle();
-                            self::log("[{$product->ShopifyID}] Published product {$product->Title}", self::SUCCESS);
+                            self::log(
+                                "[{$product->ShopifyID}] Published product {$product->Title}",
+                                self::SUCCESS
+                            );
                         } elseif (!$product->ProductActive && $product->IsPublished()) {
                             $product->doUnpublish();
-                            self::log("[{$product->ShopifyID}] Product not active on Shopify, unpublished", self::SUCCESS);
+                            self::log(
+                                "[{$product->ShopifyID}] Product not active on Shopify, unpublished",
+                                self::SUCCESS
+                            );
                         } else {
-                            self::log("[{$product->ShopifyID}] Product {$product->Title} is already published", self::SUCCESS);
+                            self::log(
+                                "[{$product->ShopifyID}] Product {$product->Title} is already published",
+                                self::SUCCESS
+                            );
                         }
                         $lastId = $shopifyProduct->cursor;
                     } else {

--- a/src/Task/ShopifyImportTask.php
+++ b/src/Task/ShopifyImportTask.php
@@ -336,8 +336,8 @@ class ShopifyImportTask extends BuildTask
                         }
 
                         $lastId = $product->ShopifyID;
-                        self::log("[{$this->parseShopifyID($shopifyCollect->node->id)}] Created collect between Product[{$product->ID}] and
-                        Collection[{$collection->ID}]", self::SUCCESS);
+                        self::log("[{$this->parseShopifyID($shopifyCollect->node->id)}] Created collect between
+                        Product[{$product->ID}] and Collection[{$collection->ID}]", self::SUCCESS);
                     }
                 }
 

--- a/src/Task/ShopifyImportTask.php
+++ b/src/Task/ShopifyImportTask.php
@@ -169,7 +169,12 @@ class ShopifyImportTask extends BuildTask
                             }
 
                             // remove unused images
-                            foreach ($product->Files()->exclude(['ID' => $keepImages]) as $image) {
+                            if (empty($keepImages)) {
+                                $files = $product->Files();
+                            } else {
+                                $files = $product->Files()->exclude(['ID' => $keepImages]);
+                            }
+                            foreach ($files as $image) {
                                 $imageId = $image->ID;
                                 $imageShopifyId = $image->ShopifyID;
                                 $image->doUnpublish();

--- a/src/Task/ShopifyImportTask.php
+++ b/src/Task/ShopifyImportTask.php
@@ -57,7 +57,7 @@ class ShopifyImportTask extends BuildTask
         exit('Done');
     }
 
-    public function importCollections(ShopifyClient $client, $sinceId = 0, $keepCollections = [])
+    public function importCollections(ShopifyClient $client, $sinceId = null, $keepCollections = [])
     {
         try {
             $collections = $client->collections(
@@ -70,7 +70,7 @@ class ShopifyImportTask extends BuildTask
 
         if (($collections = $collections['body'])) {
             $lastId = $sinceId;
-            foreach ($collections->data->shop->collections->edges as $shopifyCollection) {
+            foreach ($collections->data->collections->edges as $shopifyCollection) {
                 // Create the collection
                 if ($collection = $this->importObject(ShopifyCollection::class, $shopifyCollection->node)) {
                     $keepCollections[] = $collection->ID;
@@ -140,7 +140,7 @@ class ShopifyImportTask extends BuildTask
      *
      * @throws \Exception
      */
-    public function importProducts(ShopifyClient $client, $sinceId = 0, $keepProducts = [])
+    public function importProducts(ShopifyClient $client, $sinceId = null, $keepProducts = [])
     {
         try {
             $products = $client->products($limit = 10, $sinceId);
@@ -150,9 +150,9 @@ class ShopifyImportTask extends BuildTask
 
         if (($products = $products['body'])) {
             $lastId = $sinceId;
-            $shopifyProducts = new ArrayList((array)$products->data->shop->products->edges);
+            $shopifyProducts = new ArrayList((array)$products->data->products->edges);
             if ($shopifyProducts->exists()) {
-                foreach ($products->data->shop->products->edges as $shopifyProduct) {
+                foreach ($products->data->products->edges as $shopifyProduct) {
                     // Create the product
                     if ($product = $this->importObject(ShopifyProduct::class, $shopifyProduct->node)) {
                         $keepProducts[] = $product->ID;

--- a/tests/Page/ShopifyProductTest.php
+++ b/tests/Page/ShopifyProductTest.php
@@ -30,8 +30,8 @@ class ShopifyProductTest extends SapphireTest
         $this->assertNotNull($fields->dataFieldByName('ShopifyID'));
         $this->assertNotNull($fields->dataFieldByName('Vendor'));
         $this->assertNotNull($fields->dataFieldByName('ProductType'));
-        $this->assertNotNull($fields->dataFieldByName('Tags'));
-        $this->assertNotNull($fields->dataFieldByName('Status'));
+        //$this->assertNotNull($fields->dataFieldByName('Tags'));
+        //$this->assertNotNull($fields->dataFieldByName('Status'));
         $this->assertNotNull($fields->dataFieldByName('Variants'));
         $this->assertNotNull($fields->dataFieldByName('Files'));
         $this->assertNotNull($fields->dataFieldByName('Collections'));


### PR DESCRIPTION
- REFACTOR ShopifyClient to utilize `Osiset\BasicShopifyAPI\BasicShopifyAPI` for GraphQL queries
- REFACTOR `ShopifyClient::products()` to use `graph()` API method for getting product list
- REFACTOR `ShopifyClient::product()` to use `graph()` API method for getting product information