### PR TITLE
BUGFIX getProductList does not account for virtual categories

### DIFF
--- a/src/Page/ShopifyCollection.php
+++ b/src/Page/ShopifyCollection.php
@@ -158,17 +158,17 @@ class ShopifyCollection extends \Page
      */
     public function getProductList()
     {
-        $categories = ShopifyCollection::get()->filter('ParentID', $this->data()->ID)->column('ID');
-        $categories[] = $this->data()->ID;
+        $id = $this->CopyContentFromID ?: $this->ID;
+        $categories = ShopifyCollection::get()->filter('ParentID', $id)->column('ID');
+        $categories[] = $this->ID;
 
-        $classes = [
-            VirtualPage::class,
-            RedirectorPage::class,
-        ];
-
-        foreach (ClassInfo::subclassesFor(ShopifyProduct::class) as $class) {
-            $classes[] = $class;
-        }
+        $classes = array_merge(
+            [
+                VirtualPage::class,
+                RedirectorPage::class,
+            ],
+            ClassInfo::subclassesFor(ShopifyProduct::class)
+        );
 
         $products = SiteTree::get()
             ->filter('ClassName', $classes)

--- a/src/Page/ShopifyCollection.php
+++ b/src/Page/ShopifyCollection.php
@@ -160,7 +160,7 @@ class ShopifyCollection extends \Page
     {
         $id = $this->CopyContentFromID ?: $this->ID;
         $categories = ShopifyCollection::get()->filter('ParentID', $id)->column('ID');
-        $categories[] = $this->ID;
+        $categories[] = $id;
 
         $classes = array_merge(
             [


### PR DESCRIPTION
This will assign the ID used for queries based on the ContentCopyID if it is available